### PR TITLE
Try to use curl when wget is missing.

### DIFF
--- a/paver.sh
+++ b/paver.sh
@@ -259,7 +259,7 @@ set_download_commands() {
     if [ $? -eq 0 ]; then
         set -o errexit
         echo "Using CURL for online operations..."
-        ONLINETEST_CMD="curl --head --fail --output /dev/null"
+        ONLINETEST_CMD="curl --fail --silent --head --output /dev/null"
         # Use 1M dot to reduce console pollution.
         DOWNLOAD_CMD="curl --remote-name"
         return

--- a/paver.sh
+++ b/paver.sh
@@ -246,19 +246,19 @@ pip_install() {
 #
 set_download_commands() {
     set +o errexit
-    command -v wget
+    command -v wget > /dev/null
     if [ $? -eq 0 ]; then
         set -o errexit
-        echo "Using WGET for online operations..."
+        echo "Using WGET for downloading Python package..."
         ONLINETEST_CMD="wget --spider --quiet"
         # Use 1MB dots to reduce output, avoiding polluting Buildbot's pages.
         DOWNLOAD_CMD="wget --progress=dot --execute dot_bytes=1m"
         return
     fi
-    command -v curl
+    command -v curl > /dev/null
     if [ $? -eq 0 ]; then
         set -o errexit
-        echo "Using CURL for online operations..."
+        echo "Using CURL for downloading Python package..."
         ONLINETEST_CMD="curl --fail --silent --head --output /dev/null"
         DOWNLOAD_CMD="curl --remote-name"
         return
@@ -753,7 +753,6 @@ detect_os() {
 
 detect_os
 update_path_variables
-set_download_commands
 
 if [ "$COMMAND" = "clean" ] ; then
     clean_build
@@ -769,6 +768,9 @@ if [ "$COMMAND" = "detect_os" ] ; then
     write_default_values
     exit 0
 fi
+
+# Following functions need to check or download online packages.
+set_download_commands
 
 if [ "$COMMAND" = "get_python" ] ; then
     OS=$2

--- a/paver.sh
+++ b/paver.sh
@@ -251,7 +251,8 @@ set_download_commands() {
         set -o errexit
         echo "Using WGET for online operations..."
         ONLINETEST_CMD="wget --spider --quiet"
-        DOWNLOAD_CMD="wget"
+        # Use 1MB dots to reduce output, avoiding polluting Buildbot's pages.
+        DOWNLOAD_CMD="wget --progress=dot --execute dot_bytes=1m"
         return
     fi
     command -v curl
@@ -259,7 +260,6 @@ set_download_commands() {
         set -o errexit
         echo "Using CURL for online operations..."
         ONLINETEST_CMD="curl --fail --silent --head --output /dev/null"
-        # Use 1M dot to reduce console pollution.
         DOWNLOAD_CMD="curl --remote-name"
         return
     fi

--- a/paver.sh
+++ b/paver.sh
@@ -241,6 +241,32 @@ pip_install() {
     fi
 }
 
+#
+# Check for wget or curl and set needed download commands accordingly.
+#
+set_download_commands() {
+    set +o errexit
+    command -v wget
+    if [ $? -eq 0 ]; then
+        set -o errexit
+        echo "Using WGET for online operations..."
+        ONLINETEST_CMD="wget --spider --no-verbose"
+        # Use 1M dot to reduce console pollution.
+        DOWNLOAD_CMD="wget --progress=dot -e dotbytes=1M"
+        return
+    fi
+    command -v curl
+    if [ $? -eq 0 ]; then
+        set -o errexit
+        echo "Using CURL for online operations..."
+        ONLINETEST_CMD="curl --head --fail --output /dev/null"
+        # Use 1M dot to reduce console pollution.
+        DOWNLOAD_CMD="curl --remote-name"
+        return
+    fi
+    echo "Missing wget or curl! One of them is needed for online operations."
+    exit 30
+}
 
 #
 # Download and extract a binary distribution.
@@ -261,9 +287,7 @@ get_binary_dist() {
         rm -rf $dist_name
         rm -f $tar_gz_file
         rm -f $tar_file
-        # Use 1M dot to reduce console pollution.
-        execute wget --progress=dot -e dotbytes=1M \
-            $remote_base_url/${tar_gz_file}
+        execute $DOWNLOAD_CMD $remote_base_url/${tar_gz_file}
         execute gunzip $tar_gz_file
         execute tar -xf $tar_file
         rm -f $tar_gz_file
@@ -277,12 +301,10 @@ get_binary_dist() {
 #
 test_version_exists() {
     local remote_base_url=$1
-    local wget_test
     local target_file=python-${PYTHON_VERSION}-${OS}-${ARCH}.tar.gz
 
-    wget --spider $remote_base_url/${OS}/${ARCH}/$target_file
-    wget_test=$?
-    return $wget_test
+    $ONLINETEST_CMD $remote_base_url/${OS}/${ARCH}/$target_file
+    return $?
 }
 
 #
@@ -674,6 +696,7 @@ detect_os() {
             OS="osx"
         else
             echo "Unsupported Mac OS X version: $os_version_raw."
+            exit 17
         fi
 
 
@@ -731,6 +754,7 @@ detect_os() {
 
 detect_os
 update_path_variables
+set_download_commands
 
 if [ "$COMMAND" = "clean" ] ; then
     clean_build

--- a/paver.sh
+++ b/paver.sh
@@ -250,9 +250,8 @@ set_download_commands() {
     if [ $? -eq 0 ]; then
         set -o errexit
         echo "Using WGET for online operations..."
-        ONLINETEST_CMD="wget --spider --no-verbose"
-        # Use 1M dot to reduce console pollution.
-        DOWNLOAD_CMD="wget --progress=dot -e dotbytes=1M"
+        ONLINETEST_CMD="wget --spider --quiet"
+        DOWNLOAD_CMD="wget"
         return
     fi
     command -v curl


### PR DESCRIPTION
On macOS we want to not require Homebrew any more.

The only thing missing is `wget`, if Apple's _Command Line Tools_ are installed.

But we can use `curl` instead, which I already do on my OpenBSD desktop (through a shell shim).

**Drive-by fix**:
  * use `wget` flags compatible with Busybox.