### PR TITLE
Support for Busybox' wget.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
-DEFAULT_VALUES
-cache/
+/build/
+/dist/
+/DEFAULT_VALUES
+/build-*
+/cache
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/pavement.py
+++ b/pavement.py
@@ -14,7 +14,7 @@ from paver.tasks import help
 BUILD_PACKAGES = [
     # Main slave package.
     # We specify a custom twisted package, to use our patched version.
-    'twisted==12.1.0.chevah12',
+    'twisted==15.5.0.chevah7',
     'buildbot-slave==0.8.11.pre.143.gac88f1b.c1',
 
     'zope.interface==3.8.0',

--- a/paver.conf
+++ b/paver.conf
@@ -1,4 +1,4 @@
-BASE_REQUIREMENTS='chevah-brink==0.71.1 paver==1.2.4'
-PYTHON_CONFIGURATION='default@2.7.16.17804ad2:solaris10@2.7.8.17804ad24'
+BASE_REQUIREMENTS='chevah-brink==0.72.0 paver==1.2.4'
+PYTHON_CONFIGURATION='default@2.7.17.f208293c:sol10@2.7.8.f208293c'
 BINARY_DIST_URI='http://binary.chevah.com/production'
 PIP_INDEX='http://pypi.chevah.com'

--- a/paver.sh
+++ b/paver.sh
@@ -248,19 +248,25 @@ set_download_commands() {
     set +o errexit
     command -v curl > /dev/null
     if [ $? -eq 0 ]; then
-        set -o errexit
         # Using CURL for downloading Python package.
-        ONLINETEST_CMD="curl --fail --silent --head --output /dev/null"
         DOWNLOAD_CMD="curl --remote-name"
+        ONLINETEST_CMD="curl --fail --silent --head --output /dev/null"
+        set -o errexit
         return
     fi
     command -v wget > /dev/null
     if [ $? -eq 0 ]; then
-        set -o errexit
         # Using WGET for downloading Python package.
+        wget --version > /dev/null 2>&1
+        if [ $? -ne 0 ]; then
+            # This is not GNU Wget, could be the more frugal wget from Busybox.
+            DOWNLOAD_CMD="wget"
+        else
+            # Use 1MB dots to reduce output, avoiding polluting Buildbot's pages.
+            DOWNLOAD_CMD="wget --progress=dot --execute dot_bytes=1m"
+        fi
         ONLINETEST_CMD="wget --spider --quiet"
-        # Use 1MB dots to reduce output, avoiding polluting Buildbot's pages.
-        DOWNLOAD_CMD="wget --progress=dot --execute dot_bytes=1m"
+        set -o errexit
         return
     fi
     (>&2 echo "Missing wget/curl! One of them is needed for online operations.")

--- a/paver.sh
+++ b/paver.sh
@@ -242,10 +242,18 @@ pip_install() {
 }
 
 #
-# Check for wget or curl and set needed download commands accordingly.
+# Check for curl or wget and set needed download commands accordingly.
 #
 set_download_commands() {
     set +o errexit
+    command -v curl > /dev/null
+    if [ $? -eq 0 ]; then
+        set -o errexit
+        # Using CURL for downloading Python package.
+        ONLINETEST_CMD="curl --fail --silent --head --output /dev/null"
+        DOWNLOAD_CMD="curl --remote-name"
+        return
+    fi
     command -v wget > /dev/null
     if [ $? -eq 0 ]; then
         set -o errexit
@@ -253,14 +261,6 @@ set_download_commands() {
         ONLINETEST_CMD="wget --spider --quiet"
         # Use 1MB dots to reduce output, avoiding polluting Buildbot's pages.
         DOWNLOAD_CMD="wget --progress=dot --execute dot_bytes=1m"
-        return
-    fi
-    command -v curl > /dev/null
-    if [ $? -eq 0 ]; then
-        set -o errexit
-        # Using CURL for downloading Python package.
-        ONLINETEST_CMD="curl --fail --silent --head --output /dev/null"
-        DOWNLOAD_CMD="curl --remote-name"
         return
     fi
     (>&2 echo "Missing wget/curl! One of them is needed for online operations.")
@@ -502,7 +502,7 @@ check_os_version() {
         exit 12
     fi
 
-    # Using '.' as a delimiter, populate the version_raw_* arrays.
+    # Using '.' as a delimiter, populate the version_* arrays.
     IFS=. read -a version_raw_array <<< "$version_raw"
     IFS=. read -a version_good_array <<< "$version_good"
 

--- a/paver.sh
+++ b/paver.sh
@@ -242,18 +242,10 @@ pip_install() {
 }
 
 #
-# Check for curl or wget and set needed download commands accordingly.
+# Check for wget or curl and set needed download commands accordingly.
 #
 set_download_commands() {
     set +o errexit
-    command -v curl > /dev/null
-    if [ $? -eq 0 ]; then
-        # Using CURL for downloading Python package.
-        DOWNLOAD_CMD="curl --remote-name"
-        ONLINETEST_CMD="curl --fail --silent --head --output /dev/null"
-        set -o errexit
-        return
-    fi
     command -v wget > /dev/null
     if [ $? -eq 0 ]; then
         # Using WGET for downloading Python package.
@@ -269,7 +261,15 @@ set_download_commands() {
         set -o errexit
         return
     fi
-    (>&2 echo "Missing curl and wget! One is needed for online operations.")
+    command -v curl > /dev/null
+    if [ $? -eq 0 ]; then
+        # Using CURL for downloading Python package.
+        DOWNLOAD_CMD="curl --remote-name"
+        ONLINETEST_CMD="curl --fail --silent --head --output /dev/null"
+        set -o errexit
+        return
+    fi
+    (>&2 echo "Missing wget and curl! One is needed for online operations.")
     exit 3
 }
 

--- a/paver.sh
+++ b/paver.sh
@@ -262,14 +262,14 @@ set_download_commands() {
             # This is not GNU Wget, could be the more frugal wget from Busybox.
             DOWNLOAD_CMD="wget"
         else
-            # Use 1MB dots to reduce output, avoiding polluting Buildbot's pages.
+            # Use 1MB dots to reduce output and avoid polluting Buildbot pages.
             DOWNLOAD_CMD="wget --progress=dot --execute dot_bytes=1m"
         fi
         ONLINETEST_CMD="wget --spider --quiet"
         set -o errexit
         return
     fi
-    (>&2 echo "Missing wget/curl! One of them is needed for online operations.")
+    (>&2 echo "Missing curl and wget! One is needed for online operations.")
     exit 3
 }
 

--- a/paver.sh
+++ b/paver.sh
@@ -676,13 +676,6 @@ detect_os() {
                         fi
                         set_os_if_not_generic "ubuntu" $os_version_chevah
                         ;;
-                    debian)
-                        os_version_raw="$VERSION_ID"
-                        # Debian 7/8 have OpenSSL 1.0.1, use generic Linux.
-                        check_os_version "$distro_fancy_name" 9 \
-                            "$os_version_raw" os_version_chevah
-                        set_os_if_not_generic "debian" $os_version_chevah
-                        ;;
                     alpine)
                         os_version_raw="$VERSION_ID"
                         check_os_version "$distro_fancy_name" 3.6 \
@@ -690,7 +683,7 @@ detect_os() {
                         set_os_if_not_generic "alpine" $os_version_chevah
                         ;;
                     *)
-                        # Unsupported modern distros, such as Arch Linux.
+                        # Unsupported modern distros such as Debian, Arch, etc.
                         check_linux_glibc
                         ;;
                 esac
@@ -780,10 +773,16 @@ detect_os() {
         "amd64"|"x86_64")
             ARCH="x64"
             case "$OS" in
-                win|sol10)
-                    # On Windows, only 32bit builds are currently supported.
+                sol10*)
                     # On Solaris 10, x64 built fine prior to adding "bcrypt".
                     ARCH="x86"
+                    ;;
+                win)
+                    # 32bit build on Windows 2016, 64bit otherwise.
+                    win_ver=$(systeminfo.exe | grep "OS Name" | cut -b 28-56)
+                    if [ "$win_ver" = "Microsoft Windows Server 2016" ]; then
+                        ARCH="x86"
+                    fi
                     ;;
             esac
             ;;


### PR DESCRIPTION
I've noticed on my Alpine Linux VM that the `wget` surrogate provided by Busybox is problematic because it fails to run with the current command switches.

This is not an issue on our slaves, because we install GNU `wget` through Salt.

This makes it work with `wget` from Busybox too, if GNU `wget` is missing.

**Drive-by fixes**:
  * updated paver stuff from `server` repo
  * improved `.gitignore`
  * updated to the latest chevah flavour of `twisted`, version 15.5.0.chevah7.